### PR TITLE
CE-425 ParserUtil::sanitizeUrl() in Location::setUrl() adds unnecessa…

### DIFF
--- a/Entity/TwitterUser.php
+++ b/Entity/TwitterUser.php
@@ -11,6 +11,7 @@
 namespace CampaignChain\Location\TwitterBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use CampaignChain\CoreBundle\Util\ParserUtil;
 
 /**
  * @ORM\Entity
@@ -142,7 +143,7 @@ class TwitterUser
      */
     public function setProfileUrl($profileUrl)
     {
-        $this->profileUrl = $profileUrl;
+        $this->profileUrl = ParserUtil::sanitizeUrl($profileUrl);
 
         return $this;
     }


### PR DESCRIPTION
…ry trailing slash that causes e.g. GoToWebinar links to not work
