### PR TITLE
CampaignChain/campaignchain#174

### DIFF
--- a/Job/ReportTwitterUserMetrics.php
+++ b/Job/ReportTwitterUserMetrics.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ *
+ * This file is part of the CampaignChain package.
+ *
+ * (c) CampaignChain, Inc. <info@campaignchain.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace CampaignChain\Location\TwitterBundle\Job;
+
+use CampaignChain\CoreBundle\Entity\Location;
+use CampaignChain\CoreBundle\Entity\SchedulerReportLocation;
+use CampaignChain\CoreBundle\Job\JobReportInterface;
+use Doctrine\ORM\EntityManager;
+
+class ReportTwitterUserMetrics implements JobReportInterface
+{
+    const BUNDLE_NAME = 'campaignchain/location-twitter';
+    const METRIC_FOLLOWERS = 'Followers';
+
+    protected $em;
+    protected $container;
+
+    protected $message;
+
+    public function __construct(EntityManager $em, $container)
+    {
+        $this->em = $em;
+        $this->container = $container;
+    }
+
+    public function schedule($location, $facts = null)
+    {
+        $scheduler = new SchedulerReportLocation();
+        $scheduler->setLocation($location);
+        $scheduler->setInterval('1 hour');
+        $this->em->persist($scheduler);
+
+        $facts[self::METRIC_FOLLOWERS] = 0;
+
+        $factService = $this->container->get('campaignchain.core.fact');
+        $factService->addLocationFacts(self::BUNDLE_NAME, $location, $facts);
+
+    }
+
+    public function execute($locationId)
+    {
+        $client = $this->container->get('campaignchain.channel.twitter.rest.client');
+        $location = $this->em->getRepository('CampaignChainCoreBundle:Location')->find($locationId);
+        $connection = $client->connectByLocation($location);
+
+        if ($connection) {
+
+            $request = $connection->get('users/show.json?user_id='.$location->getIdentifier());
+            $response = $request->send()->json();
+            $followers = $response['followers_count'];
+        } else {
+            return self::STATUS_ERROR;
+        }
+
+        // Add report data.
+        $facts[self::METRIC_FOLLOWERS] = $followers;
+
+        $factService = $this->container->get('campaignchain.core.fact');
+        $factService->addLocationFacts(self::BUNDLE_NAME, $location, $facts);
+
+        $this->message = 'Added to report: followers = '.$followers . '.';
+
+        return self::STATUS_OK;
+    }
+
+    public function getMessage(){
+        return $this->message;
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -14,3 +14,6 @@ services:
     campaignchain.location.twitter_user:
         class: CampaignChain\Location\TwitterBundle\EntityService\TwitterUserService
         arguments: [ @doctrine.orm.entity_manager, @service_container ]
+    campaignchain.job.report.location.twitter:
+        class: CampaignChain\Location\TwitterBundle\Job\ReportTwitterUserMetrics
+        arguments: [ @doctrine.orm.entity_manager, @service_container ]

--- a/campaignchain.yml
+++ b/campaignchain.yml
@@ -8,5 +8,11 @@
 modules:
     campaignchain-twitter-user:
         display_name: Twitter user stream
+        services:
+            report: campaignchain.job.report.location.twitter
+        metrics:
+            location:
+                - "Followers"
+
     campaignchain-twitter-status:
         display_name: Twitter post (aka Tweet)


### PR DESCRIPTION
CampaignChain/campaignchain#174
- trigger scheduler on creation of facebook page location
- trigger scheduler on creation of twitter user location
- add job for facebook location metrics
- add job for twitter location metrics
- add report module for location
- create template for location report
- update job command
- update scheduler command
- update installer
- update routes and services in core
- create fact and metric entities
- remove channel report stuff
- update fact service
- fix existing entities
- update campaignchain.yml configs
- create database migrations
- update amariki demo/test fixtures
- fix code style
